### PR TITLE
Fix issue #16: [Create Middleware for JWT Verification] + [5]

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -80,4 +80,3 @@ export const deleteTask = (id: number) => {
     console.log(`Row(s) deleted: ${this.changes}`);
   });
 };
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,11 @@ import express from 'express';
 import { createTask, readTasks, updateTask, deleteTask, createUser, authenticateUser } from './database';
 import jwt from 'jsonwebtoken';
 import expressJwt from 'express-jwt';
-import dotenv from 'dotenv';
-dotenv.config();
+import jwtMiddleware from './middleware/jwtMiddleware';
 
 const app = express();
 
-app.use(expressJwt({ secret: process.env.JWT_SECRET || 'secret', algorithms: ['HS256'] }).unless({ path: ['/login', '/register'] }));
+app.use(jwtMiddleware);
 
 const port = 54902;
 

--- a/src/middleware/jwtMiddleware.ts
+++ b/src/middleware/jwtMiddleware.ts
@@ -1,0 +1,13 @@
+import expressJwt from 'express-jwt';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const jwtMiddleware = expressJwt({
+  secret: process.env.JWT_SECRET || 'secret',
+  algorithms: ['HS256']
+}).unless({
+  path: ['/login', '/register']
+});
+
+export default jwtMiddleware;


### PR DESCRIPTION
This pull request fixes #16.

The issue was to create middleware using `express-jwt` to protect endpoints that require authentication. The changes made include the creation of a new middleware directory and a `jwtMiddleware.ts` file, which defines the JWT middleware using `express-jwt`. This middleware is configured to protect all endpoints except `/login` and `/register`, as specified by the `.unless` method. The middleware is then imported and used in the main application file (`index.ts`) to replace the previous inline middleware setup. These changes effectively address the issue by modularizing the JWT authentication middleware, making it reusable and maintaining the intended functionality of protecting specific endpoints.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌